### PR TITLE
Fix scaling issue on linux with high DPI monitor

### DIFF
--- a/demo/nuidemo/source/gui_root.d
+++ b/demo/nuidemo/source/gui_root.d
@@ -51,7 +51,7 @@ class GuiRoot : Component, Renderable2D, Updatable {
         auto ui_font = raylib.LoadFontEx("./res/SourceSansPro-Regular.ttf", UI_FS, null, 0);
         raylib.SetTextureFilter(ui_font.texture, raylib.TextureFilter.TEXTURE_FILTER_POINT);
         ctx = InitNuklearEx(ui_font, UI_FS);
-        ui_scale = Core.window.dpi_scale * Core.render_oversample_factor;
+        ui_scale = Core.window.dpi_max_scale * Core.render_oversample_factor;
         SetNuklearScaling(ctx, ui_scale);
         apply_style(ctx);
 

--- a/demo/nuidemo/source/gui_scene.d
+++ b/demo/nuidemo/source/gui_scene.d
@@ -44,7 +44,7 @@ class GuiScene : Scene2D {
 
     override void render_hook() {
         // draw fps in bottom right corner
-        auto ui_scale = cast(int)(Core.window.dpi_scale * Core.render_oversample_factor);
+        auto ui_scale = cast(int)(Core.window.dpi_max_scale * Core.render_oversample_factor);
         auto font_size = 16 * ui_scale;
         raylib.DrawText(
             format("%s", Core.fps).c_str(),

--- a/source/re/core.d
+++ b/source/re/core.d
@@ -352,8 +352,8 @@ abstract class Core {
     private void calculate_render_resolution() {
         // since window was resized, update our render resolution
         // first get the new window size
-        auto render_res_x = window.render_width;
-        auto render_res_y = window.render_height;
+        auto render_res_x = window.render_width * window.dpi_scale_x;
+        auto render_res_y = window.render_height * window.dpi_scale_y;
 
         // set mouse scale
         auto mouse_scale_factor = 1.0 * scale_factor;
@@ -373,7 +373,7 @@ abstract class Core {
 
     /// overall scale factor from screen space coordinates to render space
     static @property float scale_factor() {
-        return window.dpi_scale * render_oversample_factor;
+        return window.dpi_max_scale * render_oversample_factor;
     }
 }
 

--- a/source/re/gfx/window.d
+++ b/source/re/gfx/window.d
@@ -49,9 +49,19 @@ class Window {
         raylib.CloseWindow();
     }
 
-    public @property float dpi_scale() {
+    public @property float dpi_max_scale() {
         auto scale_dpi_vec = raylib.GetWindowScaleDPI();
         return max(scale_dpi_vec.x, scale_dpi_vec.y);
+    }
+
+    public @property float dpi_scale_x() {
+        auto scale_dpi_vec = raylib.GetWindowScaleDPI();
+        return scale_dpi_vec.x;
+    }
+
+    public @property float dpi_scale_y() {
+        auto scale_dpi_vec = raylib.GetWindowScaleDPI();
+        return scale_dpi_vec.y;
     }
 
     public @property int screen_width() {
@@ -63,7 +73,7 @@ class Window {
     }
 
     public @property Rectangle screen_bounds() {
-        return Rectangle(0, 0, screen_width, screen_height);
+        return Rectangle(0, 0, screen_width * Core.window.dpi_scale_x, screen_height * Core.window.dpi_scale_y);
     }
 
     public @property int render_width() {


### PR DESCRIPTION
You may want to change names of variables or functions here. Fixes the issue, for all demos except multiscene, on Linux and works on MacOS M1 (not tested on Windows).  Fixes issue #20 